### PR TITLE
Add toolbar button icon for logging action

### DIFF
--- a/nowbutton.py
+++ b/nowbutton.py
@@ -20,13 +20,13 @@ from datetime import datetime, timedelta
 from datetime import date as dateclass
 from codecs import getdecoder
 
-import gtk
 
 from zim.config import StringAllowEmpty
 from zim.plugins import PluginClass
 from zim.actions import action
 from zim.gui.pageview import PageViewExtension
 from zim.config import ConfigManager
+from gi.repository import Gtk as gtk
 
 
 logger = logging.getLogger('zim.plugins.nowbutton')
@@ -72,10 +72,7 @@ class NowButtonMainWindowExtension(PageViewExtension):
         def __init__(self, plugin, pageview):
                 PageViewExtension.__init__(self, plugin, pageview)
 
-        @action(
-                _('Log Entry'),
-                '<Primary><Shift>E'
-        ) # T: menu item
+        @action(_('Log Entry'), icon=gtk.STOCK_JUMP_TO, menuhints='view',accelerator='<Primary><Shift>J') # T: menu item
         def now_button_clicked(self):
 
                 calendar_config=ConfigManager.preferences['JournalPlugin']


### PR DESCRIPTION
The upstream code had  stock=gtk.STOCK_JUMP_TO for the icon
However, if we use the stock attribute - we get the following error
TypeError: action() got an unexpected keyword argument 'stock'

So that seems to now be replaced with the 'icon' attribute.
But we still get the following error:
  @action(_('Log Entry'), icon=gtk.STOCK_JUMP_TO,
  menuhints='view',accelerator='<Primary><Shift>J') # T: menu item

    File "gi/__init__.py", line 69, in __getattr__
    AttributeError: When using gi.repository you must not import static
    modules like "gobject".
     Please change all occurrences of "import gobject" to "from
     gi.repository import GObject".

Got a hint about that error from:
https://github.com/rabbitvcs/rabbitvcs/pull/189/commits/1ced574155ed3068de9d67adff6424ada9984d34

Replaced import gtk
with
from gi.repository import Gtk as gtk

And finally, we get a Log Entry icon in the toolbar!

Note: changed accelerator key to Ctrl+Shift+J since Ctrl+Shift+E was conflicting with another plugin. Would be good to add this accelerator key to the plugin configuration.